### PR TITLE
add 2017 items links; new ACL anthology links modified

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,5 +67,7 @@ proceedings:
     aclkey: U15
   - year: 2016
     aclkey: U16
+  - year: 2017
+    aclkey: U17
 zeroth_proc_year: 2002
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -65,6 +65,6 @@ For any comments or questions about these pages please contact the <a href="mail
 </p>   
 <!-- End of footer -->
 <br>
-Copyright 2003-2017 ALTA. Last updated: {{ site.time | date_to_string }}
+Copyright 2003-2018 ALTA. Last updated: {{ site.time | date_to_string }}
 </body>
 </html>

--- a/events/index.html
+++ b/events/index.html
@@ -30,7 +30,10 @@ to the ALTA-Announce</a> mailing list.</p>
 <ul>
   {% for proc in site.proceedings %}
     <li>
-      <a target="_blank" href="http://aclweb.org/anthology/U/{{ proc.aclkey }}">
+      <!-- <a target="_blank" href="http://aclweb.org/anthology/U/{{ proc.aclkey }}"> -->
+      <!--   Vol. {{ proc.year | minus: site.zeroth_proc_year }} ({{ proc.year }}) -->
+      <!-- </a> -->
+      <a target="_blank" href="https://aclanthology.coli.uni-saarland.de/events/alta-{{ proc.year }}">
         Vol. {{ proc.year | minus: site.zeroth_proc_year }} ({{ proc.year }})
       </a>
     </li>
@@ -41,6 +44,7 @@ to the ALTA-Announce</a> mailing list.</p>
 
 <h3>ALTA Workshops</h3>
 <ul>
+<li><a href="http://alta2017.alta.asn.au">2017</a></li>
 <li><a href="http://alta2016.alta.asn.au">2016</a></li>
 <li><a href="alta2015">2015</a></li>
 <li><a href="alta2014">2014</a></li>
@@ -60,6 +64,7 @@ to the ALTA-Announce</a> mailing list.</p>
 <h3>ALTA Shared Tasks</h3>
 
 <ul>
+<li><a href="http://www.alta.asn.au/events/sharedtask2017/">2017</a></li>
 <li><a href="http://www.alta.asn.au/events/sharedtask2016/">2016</a></li>
 <li><a href="http://www.alta.asn.au/events/sharedtask2015/">2015</a></li>
 <li><a href="http://www.alta.asn.au/events/sharedtask2014/">2014</a></li>

--- a/index.html
+++ b/index.html
@@ -290,7 +290,10 @@ Library of Australia with the ISSN 1834-7037. They are available at the <a href=
 <ul>
   {% for proc in site.proceedings %}
     <li>
-      <a target="_blank" href="http://aclweb.org/anthology/U/{{ proc.aclkey }}">
+      <!-- <a target="_blank" href="http://aclweb.org/anthology/U/{{ proc.aclkey }}"> -->
+      <!--   Vol. {{ proc.year | minus: site.zeroth_proc_year }} ({{ proc.year }}) -->
+      <!-- </a> -->
+      <a target="_blank" href="https://aclanthology.coli.uni-saarland.de/events/alta-{{ proc.year }}">
         Vol. {{ proc.year | minus: site.zeroth_proc_year }} ({{ proc.year }})
       </a>
     </li>


### PR DESCRIPTION
Hi all,

1. I've added the 2017 website and workshop links.
2. Also, I refresh the w old ACL anthology page with new one, in which the alta2017 workshop can be shown properly.

Yitong