### PR TITLE
Update information on joining ALTA

### DIFF
--- a/mailing_lists/index.html
+++ b/mailing_lists/index.html
@@ -1,23 +1,23 @@
 ---
-title: Mailing Lists
-key: mailing_lists
+title: Join ALTA
+key: join_alta
 ---
 
-<h1>Mailing Lists</h1>
+<h1>Join ALTA</h1>
 
-<p>All the information related to ALTA will be made public in the ALTA webpages and through mailing lists. Depending on your interest and involvement in ALTA you may want to register to one of these lists:</p>
+<p>Depending on your interest and involvement in ALTA you may want to register to one of these lists:</p>
 
 
-<h2>ALTA-Announce: Keep informed about ALTA news</h2>
+<h2>ALTA-Announce: Join ALTA and Keep informed about ALTA news</h2>
 
 <p>Become a member of ALTA and receive periodic announcements by the
 ALTA Executive Committee about forthcoming activities and resources of
 the Association.  This is a very low volume list of interest to
 language technology specialists and to onlookers from other
 fields. Everybody is welcome to join this list but only members of the
-ALTA executive committee can post messages. By joining this list you
+ALTA executive committee can post messages. <strong>By joining this list you
 are automatically a member of ALTA and have the right to vote for
-executive members.</p>
+     executive members</strong>.</p>
 
      <ul>
        <li><a


### PR DESCRIPTION
Changes on the information about joining ALTA. I suggest to change the path to join_alta, and redirect mailing_lists to join_alta